### PR TITLE
Fix displacement of nodes.

### DIFF
--- a/addons/dialogue_tree/scripts/BasicDialogue.gd
+++ b/addons/dialogue_tree/scripts/BasicDialogue.gd
@@ -9,8 +9,8 @@ func save_data():
 	var dict = {
 		"filename" : get_filename(),
 		"name" : name,
-		"rect_x" : rect_position.x,
-		"rect_y" : rect_position.y,
+		"rect_x" : offset.x,
+		"rect_y" : offset.y,
 		"rect_size_x" : rect_size.x,
 		"rect_size_y" : rect_size.y,
 		"Actor" : $ActorNameEdit.text,

--- a/addons/dialogue_tree/scripts/ChoiceDialogue.gd
+++ b/addons/dialogue_tree/scripts/ChoiceDialogue.gd
@@ -13,8 +13,8 @@ func save_data():
 	var dict = {
 		"filename" : get_filename(),
 		"name" : name,
-		"rect_x" : rect_position.x,
-		"rect_y" : rect_position.y,
+		"rect_x" : offset.x,
+		"rect_y" : offset.y,
 		"rect_size_x" : rect_size.x,
 		"rect_size_y" : rect_size.y,
 		"Conditonal" : $EditChoices/Conditonals.pressed,

--- a/addons/dialogue_tree/scripts/ConditonalDialogue.gd
+++ b/addons/dialogue_tree/scripts/ConditonalDialogue.gd
@@ -11,8 +11,8 @@ func save_data():
 	var dict = {
 		"filename" : get_filename(),
 		"name" : name,
-		"rect_x" : rect_position.x,
-		"rect_y" : rect_position.y,
+		"rect_x" : offset.x,
+		"rect_y" : offset.y,
 		"rect_size_x" : rect_size.x,
 		"rect_size_y" : rect_size.y,
 		"conditonal" : $Conditional.text

--- a/addons/dialogue_tree/scripts/EndNode.gd
+++ b/addons/dialogue_tree/scripts/EndNode.gd
@@ -9,8 +9,8 @@ func save_data():
 	var dict = {
 		"filename" : get_filename(),
 		"name" : name,
-		"rect_x" : rect_position.x,
-		"rect_y" : rect_position.y,
+		"rect_x" : offset.x,
+		"rect_y" : offset.y,
 		"rect_size_x" : rect_size.x,
 		"rect_size_y" : rect_size.y
 	}

--- a/addons/dialogue_tree/scripts/RandomDialogue.gd
+++ b/addons/dialogue_tree/scripts/RandomDialogue.gd
@@ -13,8 +13,8 @@ func save_data():
 	var dict = {
 		"filename" : get_filename(),
 		"name" : name,
-		"rect_x" : rect_position.x,
-		"rect_y" : rect_position.y,
+		"rect_x" : offset.x,
+		"rect_y" : offset.y,
 		"rect_size_x" : rect_size.x,
 		"rect_size_y" : rect_size.y,
 		"conditonal" : $EditBox/Conditonals.pressed,

--- a/addons/dialogue_tree/scripts/StartNode.gd
+++ b/addons/dialogue_tree/scripts/StartNode.gd
@@ -8,8 +8,8 @@ func save_data():
 	var dict = {
 		"filename" : get_filename(),
 		"name" : name,
-		"rect_x" : rect_position.x,
-		"rect_y" : rect_position.y,
+		"rect_x" : offset.x,
+		"rect_y" : offset.y,
 		"rect_size_x" : rect_size.x,
 		"rect_size_y" : rect_size.y
 	}


### PR DESCRIPTION
#7 

The problem was that the rect_position values ​​of the node were saved but when creating the nodes it was working with offset.
The displacements happened because when modifying the GrapEdit values ​​such as zoom or scroll_offset rect_position it is modified.